### PR TITLE
Install nature_bot_state_publisher_node when 'catkin build'ing in install mode

### DIFF
--- a/CMakeLists_ros1.cmake
+++ b/CMakeLists_ros1.cmake
@@ -191,6 +191,7 @@ nature_sim_test_node
 nature_gps_to_enu_node
 nature_gps_spoof_node
 nature_path_manager_node
+nature_bot_state_publisher_node
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )


### PR DESCRIPTION
When building + installing the stack in ROS noetic via:

``` shell
catkin config --install
catkin build nature
```

It currently will not install `nature_bot_state_publisher_node` to the install space. When you later run:

``` shell
source /path/to/install/setup.bash
roslaunch nature example.launch
```

you will observe errors related to this node not existing in the install space, and while the stack runs, you will observe different behavior in install vs. devel mode when looking at RVIZ without this change.